### PR TITLE
Add ScuttleButt UDP server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,12 @@ edition = "2021"
 
 [dependencies]
 bytes = "1"
-rand = "0.8"
+rand = { version = "0.8", features = ["small_rng"] }
 serde = { version="1", features=["derive"] }
 serde_json = "1"
-tokio = { version = "1.14.0", features = ["net", "sync", "rt-multi-thread", "macros"] }
+tokio = { version = "1.14.0", features = ["net", "sync", "rt-multi-thread", "macros", "time"] }
 bincode = "1.3.3"
 anyhow = "1.0.51"
 
 [dev-dependencies]
 assert-json-diff = "2"
-tokio = { version = "1.14.0", features = ["net", "sync", "rt-multi-thread", "macros", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,12 @@ edition = "2021"
 [dependencies]
 bytes = "1"
 rand = "0.8"
-serde = {version="1", features=["derive"]}
+serde = { version="1", features=["derive"] }
 serde_json = "1"
 tokio = { version = "1.14.0", features = ["net", "sync", "rt-multi-thread", "macros"] }
 bincode = "1.3.3"
+anyhow = "1.0.51"
 
 [dev-dependencies]
 assert-json-diff = "2"
+tokio = { version = "1.14.0", features = ["net", "sync", "rt-multi-thread", "macros", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ bytes = "1"
 rand = "0.8"
 serde = {version="1", features=["derive"]}
 serde_json = "1"
+tokio = { version = "1.14.0", features = ["net", "sync", "rt-multi-thread", "macros"] }
+bincode = "1.3.3"
 
 [dev-dependencies]
 assert-json-diff = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod server;
+
 mod model;
 
 use crate::model::{ClusterState, NodeState, ScuttleButtMessage};
@@ -11,12 +13,11 @@ pub struct ScuttleButt {
 }
 
 impl ScuttleButt {
-
     pub fn with_node_id(self_node_id: String) -> Self {
         ScuttleButt {
             max_transmitted_key_values: 10,
             self_node_id,
-            cluster_state_map: ClusterState::default()
+            cluster_state_map: ClusterState::default(),
         }
     }
 
@@ -24,7 +25,7 @@ impl ScuttleButt {
         self.max_transmitted_key_values = max_transmitted_key_values;
     }
 
-    pub fn create_syn_message(&mut self) -> ScuttleButtMessage {
+    pub fn create_syn_message(&self) -> ScuttleButtMessage {
         let digest = self.cluster_state_map.compute_digest();
         ScuttleButtMessage::Syn { digest }
     }
@@ -32,13 +33,17 @@ impl ScuttleButt {
     pub fn process_message(&mut self, msg: ScuttleButtMessage) -> Option<ScuttleButtMessage> {
         match msg {
             ScuttleButtMessage::Syn { digest } => {
-                let delta = self.cluster_state_map.compute_delta(&digest, self.max_transmitted_key_values);
+                let delta = self
+                    .cluster_state_map
+                    .compute_delta(&digest, self.max_transmitted_key_values);
                 let digest = self.cluster_state_map.compute_digest();
                 Some(ScuttleButtMessage::SynAck { delta, digest })
             }
             ScuttleButtMessage::SynAck { digest, delta } => {
                 self.cluster_state_map.apply_delta(delta);
-                let delta = self.cluster_state_map.compute_delta(&digest, self.max_transmitted_key_values);
+                let delta = self
+                    .cluster_state_map
+                    .compute_delta(&digest, self.max_transmitted_key_values);
                 Some(ScuttleButtMessage::Ack { delta })
             }
             ScuttleButtMessage::Ack { delta } => {

--- a/src/model.rs
+++ b/src/model.rs
@@ -2,7 +2,7 @@ use rand::prelude::SliceRandom;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
-use std::collections::hash_map::Entry;
+use std::collections::hash_map::{Entry, Keys};
 use std::collections::{BinaryHeap, HashMap};
 use std::iter;
 
@@ -145,8 +145,8 @@ impl ClusterState {
         self.node_states.get(node_id)
     }
 
-    pub fn nodes(&self) -> Vec<String> {
-        self.node_states.keys().cloned().collect()
+    pub fn nodes(&self) -> Keys<'_, String, NodeState> {
+        self.node_states.keys()
     }
 
     pub fn apply_delta(&mut self, delta: Delta) {

--- a/src/model.rs
+++ b/src/model.rs
@@ -145,6 +145,10 @@ impl ClusterState {
         self.node_states.get(node_id)
     }
 
+    pub fn nodes(&self) -> Vec<String> {
+        self.node_states.keys().cloned().collect()
+    }
+
     pub fn apply_delta(&mut self, delta: Delta) {
         for (node_id, node_delta) in delta.node_deltas {
             let mut node_state_map = self

--- a/src/model.rs
+++ b/src/model.rs
@@ -54,7 +54,7 @@ impl Delta {
 ///
 /// It is equivalent to a map
 /// peer -> max version.
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Digest {
     pub(crate) node_max_version: HashMap<String, Version>,
 }
@@ -72,7 +72,7 @@ impl Digest {
 /// between node A and node B.
 /// The names {Syn, SynAck, Ack} of the different steps are borrowed from
 /// TCP Handshake.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum ScuttleButtMessage {
     /// Node A initiates handshakes.
     Syn { digest: Digest },
@@ -126,7 +126,7 @@ impl NodeState {
         assert!(version > self.max_version);
         self.max_version = version;
         self.key_values
-            .insert(key.to_string(), VersionedValue { version, value });
+            .insert(key, VersionedValue { version, value });
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -118,9 +118,7 @@ impl UdpServer {
                     }
                     Err(err) => return Err(err.into()),
                 },
-                _ = interval.tick() => {
-                    let _ = self.gossip_multiple(&mut rng);
-                },
+                _ = interval.tick() => self.gossip_multiple(&mut rng).await,
                 message = self.channel.recv() => match message {
                     Some(ChannelMessage::Gossip(addr)) => {
                         let _ = self.gossip(addr).await;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,93 @@
+use std::error::Error;
+
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio::task::JoinHandle;
+
+use crate::ScuttleButt;
+
+/// Buffer size for UDP messages.
+const BUF_SIZE: usize = 4096;
+
+/// UDP ScuttleButt server.
+pub struct ScuttleServer {
+    channel: UnboundedSender<ChannelMessage>,
+    join_handle: JoinHandle<()>,
+}
+
+impl ScuttleServer {
+    /// Launch a new server.
+    ///
+    /// This will start the ScuttleButt server as a new Tokio background task.
+    pub fn spawn(node_id: impl Into<String>, port: u16) -> Result<Self, Box<dyn Error>> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let node_id = node_id.into();
+
+        let join_handle = tokio::spawn(async move {
+            let _ = listen(rx, node_id, port).await;
+        });
+
+        Ok(Self {
+            channel: tx,
+            join_handle,
+        })
+    }
+
+    /// Perform a ScuttleButt "handshake" with another UDP server.
+    pub fn gossip(&self, addr: impl Into<String>) -> Result<(), Box<dyn Error>> {
+        self.channel.send(ChannelMessage::Gossip(addr.into()))?;
+        Ok(())
+    }
+
+    /// Shut the server down.
+    pub async fn shutdown(self) -> Result<(), Box<dyn Error>> {
+        self.channel.send(ChannelMessage::Shutdown)?;
+        Ok(self.join_handle.await?)
+    }
+}
+
+/// Listen on the specified UDP port for new ScuttleButt messages.
+async fn listen(
+    mut channel: UnboundedReceiver<ChannelMessage>,
+    node_id: String,
+    port: u16,
+) -> Result<(), Box<dyn Error>> {
+    let addr = format!("0.0.0.0:{}", port);
+    let socket = UdpSocket::bind(addr).await?;
+
+    // TODO: Can't mutate node state after creation.
+    let mut scuttlebutt = ScuttleButt::with_node_id(node_id);
+
+    let mut buf = [0; BUF_SIZE];
+    loop {
+        tokio::select! {
+            Ok((len, addr)) = socket.recv_from(&mut buf) => {
+                // Handle gossip from other servers.
+                let message = bincode::deserialize(&buf[..len])?;
+                let response = scuttlebutt.process_message(message);
+
+                // Send reply if necessary.
+                if let Some(message) = response {
+                    let message = bincode::serialize(&message)?;
+                    let _ = socket.send_to(&message, addr).await?;
+                }
+            },
+            Some(message) = channel.recv() => match message {
+                ChannelMessage::Gossip(addr) => {
+                    let syn = scuttlebutt.create_syn_message();
+                    let message = bincode::serialize(&syn)?;
+                    let _ = socket.send_to(&message, addr).await?;
+                },
+                ChannelMessage::Shutdown => break,
+            },
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+enum ChannelMessage {
+    Gossip(String),
+    Shutdown,
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -33,7 +33,7 @@ impl ScuttleServer {
     /// Launch a new server.
     ///
     /// This will start the ScuttleButt server as a new Tokio background task.
-    pub fn spawn(address: impl Into<String>, seed_nodes: Vec<String>) -> Self {
+    pub fn spawn(address: impl Into<String>, seed_nodes: &[String]) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
 
         let scuttlebutt = Arc::new(Mutex::new(ScuttleButt::with_node_id(address.into())));
@@ -201,7 +201,7 @@ mod tests {
         let test_addr = "0.0.0.0:1111";
         let socket = UdpSocket::bind(test_addr).await.unwrap();
 
-        let server = ScuttleServer::spawn("0.0.0.0:1112", Vec::new());
+        let server = ScuttleServer::spawn("0.0.0.0:1112", &[]);
         server.gossip(test_addr).unwrap();
 
         let mut buf = [0; BUF_SIZE];
@@ -221,7 +221,7 @@ mod tests {
         let socket = UdpSocket::bind("0.0.0.0:2222").await.unwrap();
         let scuttlebutt = ScuttleButt::with_node_id("offline".into());
 
-        let server = ScuttleServer::spawn(server_addr, Vec::new());
+        let server = ScuttleServer::spawn(server_addr, &[]);
 
         let syn = scuttlebutt.create_syn_message();
         let message = bincode::serialize(&syn).unwrap();
@@ -241,7 +241,7 @@ mod tests {
     #[tokio::test]
     async fn ignore_broken_payload() {
         let server_addr = "0.0.0.0:3331";
-        let server = ScuttleServer::spawn(server_addr, Vec::new());
+        let server = ScuttleServer::spawn(server_addr, &[]);
         let socket = UdpSocket::bind("0.0.0.0:3332").await.unwrap();
         let scuttlebutt = ScuttleButt::with_node_id("offline".into());
 
@@ -267,7 +267,7 @@ mod tests {
     #[tokio::test]
     async fn ignore_oversized_payload() {
         let server_addr = "0.0.0.0:4441";
-        let server = ScuttleServer::spawn(server_addr, Vec::new());
+        let server = ScuttleServer::spawn(server_addr, &[]);
         let socket = UdpSocket::bind("0.0.0.0:4442").await.unwrap();
         let scuttlebutt = ScuttleButt::with_node_id("offline".into());
 
@@ -298,7 +298,7 @@ mod tests {
         let server_addr = "0.0.0.0:5551";
         let socket = UdpSocket::bind(server_addr).await.unwrap();
 
-        let server = ScuttleServer::spawn("0.0.0.0:5552", vec![server_addr.into()]);
+        let server = ScuttleServer::spawn("0.0.0.0:5552", &[server_addr.into()]);
 
         let mut buf = [0; BUF_SIZE];
         let (len, _addr) = timeout(socket.recv_from(&mut buf)).await.unwrap();

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,92 +1,162 @@
-use std::error::Error;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use tokio::net::UdpSocket;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::Mutex;
-use tokio::task::{JoinError, JoinHandle};
+use tokio::task::JoinHandle;
 
 use crate::ScuttleButt;
 
 /// Buffer size for UDP messages.
-const BUF_SIZE: usize = 4096;
+/// This value is set to avoid UDP fragmentation.
+/// https://jvns.ca/blog/2017/02/07/mtu/
+const BUF_SIZE: usize = 1_472;
 
 /// UDP ScuttleButt server.
 pub struct ScuttleServer {
-    pub scuttlebutt: Arc<Mutex<ScuttleButt>>,
-
     channel: UnboundedSender<ChannelMessage>,
-    join_handle: JoinHandle<()>,
+    scuttlebutt: Arc<Mutex<ScuttleButt>>,
+    join_handle: JoinHandle<Result<(), anyhow::Error>>,
 }
 
 impl ScuttleServer {
     /// Launch a new server.
     ///
     /// This will start the ScuttleButt server as a new Tokio background task.
-    pub fn spawn(node_id: impl Into<String>, port: u16) -> Self {
+    pub fn spawn(address: impl Into<String>, seed_nodes: Vec<String>) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
 
-        let scuttlebutt = Arc::new(Mutex::new(ScuttleButt::with_node_id(node_id.into())));
+        let scuttlebutt = Arc::new(Mutex::new(ScuttleButt::with_node_id(address.into())));
         let scuttlebutt_server = scuttlebutt.clone();
 
         let join_handle = tokio::spawn(async move {
-            let _ = listen(rx, scuttlebutt_server, port).await;
+            let mut server = UdpServer::new(rx, scuttlebutt_server).await?;
+            server.run().await
         });
 
-        Self {
+        let scuttle_server = Self {
             channel: tx,
             scuttlebutt,
             join_handle,
+        };
+
+        // Advertise the new node to all seed nodes.
+        for node_id in seed_nodes {
+            let _ = scuttle_server.gossip(node_id);
         }
+
+        scuttle_server
     }
 
-    /// Perform a ScuttleButt "handshake" with another UDP server.
-    pub fn gossip(&self, addr: impl Into<String>) {
-        let _ = self.channel.send(ChannelMessage::Gossip(addr.into()));
+    /// Call a function with access to the [`ScuttleButt`].
+    pub async fn with_scuttlebutt<F, T>(&self, mut fun: F) -> T
+    where
+        F: FnMut(&ScuttleButt) -> T,
+    {
+        let scuttlebutt = self.scuttlebutt.lock().await;
+        fun(&scuttlebutt)
+    }
+
+    /// Call a function with mutable access to the [`ScuttleButt`].
+    ///
+    /// This will automatically gossip about the changes to all known nodes.
+    pub async fn with_scuttlebutt_mut<F, T>(&self, mut fun: F) -> T
+    where
+        F: FnMut(&mut ScuttleButt) -> T,
+    {
+        let mut scuttlebutt = self.scuttlebutt.lock().await;
+        let retval = fun(&mut scuttlebutt);
+
+        // Broadcast changes to all nodes after mutation.
+        for node in scuttlebutt.cluster_state_map.nodes() {
+            let _ = self.gossip(node);
+        }
+
+        retval
     }
 
     /// Shut the server down.
-    pub async fn shutdown(self) -> Result<(), JoinError> {
+    pub async fn shutdown(self) -> Result<(), anyhow::Error> {
         let _ = self.channel.send(ChannelMessage::Shutdown);
-        self.join_handle.await
+        self.join_handle.await?
+    }
+
+    /// Perform a ScuttleButt "handshake" with another UDP server.
+    pub fn gossip(&self, addr: impl Into<String>) -> Result<(), anyhow::Error> {
+        Ok(self.channel.send(ChannelMessage::Gossip(addr.into()))?)
     }
 }
 
-/// Listen on the specified UDP port for new ScuttleButt messages.
-async fn listen(
-    mut channel: UnboundedReceiver<ChannelMessage>,
+/// UDP server for ScuttleButt communication.
+struct UdpServer {
+    channel: UnboundedReceiver<ChannelMessage>,
     scuttlebutt: Arc<Mutex<ScuttleButt>>,
-    port: u16,
-) -> Result<(), Box<dyn Error>> {
-    let addr = format!("0.0.0.0:{}", port);
-    let socket = UdpSocket::bind(addr).await?;
+    socket: Arc<UdpSocket>,
+}
 
-    let mut buf = [0; BUF_SIZE];
-    loop {
-        tokio::select! {
-            Ok((len, addr)) = socket.recv_from(&mut buf) => {
-                // Handle gossip from other servers.
-                let message = bincode::deserialize(&buf[..len])?;
-                let response = scuttlebutt.lock().await.process_message(message);
+impl UdpServer {
+    async fn new(
+        channel: UnboundedReceiver<ChannelMessage>,
+        scuttlebutt: Arc<Mutex<ScuttleButt>>,
+    ) -> anyhow::Result<Self> {
+        let socket = {
+            let address = &scuttlebutt.lock().await.self_node_id;
+            Arc::new(UdpSocket::bind(address).await?)
+        };
 
-                // Send reply if necessary.
-                if let Some(message) = response {
-                    let message = bincode::serialize(&message)?;
-                    let _ = socket.send_to(&message, addr).await?;
-                }
-            },
-            Some(message) = channel.recv() => match message {
-                ChannelMessage::Gossip(addr) => {
-                    let syn = scuttlebutt.lock().await.create_syn_message();
-                    let message = bincode::serialize(&syn)?;
-                    let _ = socket.send_to(&message, addr).await?;
-                },
-                ChannelMessage::Shutdown => break,
-            },
-        }
+        Ok(Self {
+            scuttlebutt,
+            channel,
+            socket,
+        })
     }
 
-    Ok(())
+    /// Listen for new ScuttleButt messages.
+    async fn run(&mut self) -> anyhow::Result<()> {
+        let mut buf = [0; BUF_SIZE];
+        loop {
+            tokio::select! {
+                result = self.socket.recv_from(&mut buf) => match result {
+                    Ok((len, addr)) => {
+                        let _ = self.process_package(addr, &buf[..len]).await;
+                    }
+                    Err(err) => return Err(err.into()),
+                },
+                message = self.channel.recv() => match message {
+                    Some(ChannelMessage::Gossip(addr)) => {
+                        let _ = self.gossip(addr).await;
+                    },
+                    Some(ChannelMessage::Shutdown) | None => break,
+                },
+            }
+        }
+        Ok(())
+    }
+
+    /// Process a single UDP packet.
+    async fn process_package(&self, addr: SocketAddr, data: &[u8]) -> anyhow::Result<()> {
+        // Handle gossip from other servers.
+        let message = bincode::deserialize(data)?;
+        let response = self.scuttlebutt.lock().await.process_message(message);
+
+        // Send reply if necessary.
+        if let Some(message) = response {
+            let message = bincode::serialize(&message)?;
+            self.socket.send_to(&message, addr).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Gossip to another UDP server.
+    async fn gossip(&self, addr: String) -> anyhow::Result<()> {
+        let syn = self.scuttlebutt.lock().await.create_syn_message();
+        let message = bincode::serialize(&syn)?;
+        let _ = self.socket.send_to(&message, addr).await?;
+
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -99,19 +169,27 @@ enum ChannelMessage {
 mod tests {
     use super::*;
 
+    use std::future::Future;
+    use std::time::Duration;
+
     use crate::ScuttleButtMessage;
+
+    async fn timeout<O>(future: impl Future<Output = O>) -> O {
+        tokio::time::timeout(Duration::from_millis(100), future)
+            .await
+            .unwrap()
+    }
 
     #[tokio::test]
     async fn syn() {
-        let test_addr = "0.0.0.0:2222";
+        let test_addr = "0.0.0.0:1111";
         let socket = UdpSocket::bind(test_addr).await.unwrap();
 
-        let server = ScuttleServer::spawn("node1", 3333);
-
-        server.gossip(test_addr);
+        let server = ScuttleServer::spawn("0.0.0.0:1112", Vec::new());
+        server.gossip(test_addr).unwrap();
 
         let mut buf = [0; BUF_SIZE];
-        let (len, _addr) = socket.recv_from(&mut buf).await.unwrap();
+        let (len, _addr) = timeout(socket.recv_from(&mut buf)).await.unwrap();
 
         match bincode::deserialize(&buf[..len]).unwrap() {
             ScuttleButtMessage::Syn { .. } => (),
@@ -123,20 +201,91 @@ mod tests {
 
     #[tokio::test]
     async fn syn_ack() {
-        let socket = UdpSocket::bind("0.0.0.0:4444").await.unwrap();
-        let test_scuttlebutt = ScuttleButt::with_node_id("test1".into());
+        let server_addr = "0.0.0.0:2221";
+        let socket = UdpSocket::bind("0.0.0.0:2222").await.unwrap();
+        let scuttlebutt = ScuttleButt::with_node_id("offline".into());
 
-        let server = ScuttleServer::spawn("node1", 5555);
+        let server = ScuttleServer::spawn(server_addr, Vec::new());
 
-        let syn = test_scuttlebutt.create_syn_message();
+        let syn = scuttlebutt.create_syn_message();
         let message = bincode::serialize(&syn).unwrap();
-        socket.send_to(&message, "0.0.0.0:5555").await.unwrap();
+        socket.send_to(&message, server_addr).await.unwrap();
 
         let mut buf = [0; BUF_SIZE];
-        let (len, _addr) = socket.recv_from(&mut buf).await.unwrap();
+        let (len, _addr) = timeout(socket.recv_from(&mut buf)).await.unwrap();
 
         match bincode::deserialize(&buf[..len]).unwrap() {
             ScuttleButtMessage::SynAck { .. } => (),
+            message => panic!("unexpected message: {:?}", message),
+        }
+
+        server.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn ignore_broken_payload() {
+        let server_addr = "0.0.0.0:3331";
+        let server = ScuttleServer::spawn(server_addr, Vec::new());
+        let socket = UdpSocket::bind("0.0.0.0:3332").await.unwrap();
+        let scuttlebutt = ScuttleButt::with_node_id("offline".into());
+
+        // Send broken payload.
+        socket.send_to(b"broken", server_addr).await.unwrap();
+
+        // Confirm nothing broke using a regular payload.
+        let syn = scuttlebutt.create_syn_message();
+        let message = bincode::serialize(&syn).unwrap();
+        socket.send_to(&message, server_addr).await.unwrap();
+
+        let mut buf = [0; BUF_SIZE];
+        let (len, _addr) = timeout(socket.recv_from(&mut buf)).await.unwrap();
+
+        match bincode::deserialize(&buf[..len]).unwrap() {
+            ScuttleButtMessage::SynAck { .. } => (),
+            message => panic!("unexpected message: {:?}", message),
+        }
+
+        server.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn ignore_oversized_payload() {
+        let server_addr = "0.0.0.0:4441";
+        let server = ScuttleServer::spawn(server_addr, Vec::new());
+        let socket = UdpSocket::bind("0.0.0.0:4442").await.unwrap();
+        let scuttlebutt = ScuttleButt::with_node_id("offline".into());
+
+        // Send broken payload.
+        socket.send_to(&[0; BUF_SIZE + 1], server_addr).await.unwrap();
+
+        // Confirm nothing broke using a regular payload.
+        let syn = scuttlebutt.create_syn_message();
+        let message = bincode::serialize(&syn).unwrap();
+        socket.send_to(&message, server_addr).await.unwrap();
+
+        let mut buf = [0; BUF_SIZE];
+        let (len, _addr) = timeout(socket.recv_from(&mut buf)).await.unwrap();
+
+        match bincode::deserialize(&buf[..len]).unwrap() {
+            ScuttleButtMessage::SynAck { .. } => (),
+            message => panic!("unexpected message: {:?}", message),
+        }
+
+        server.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn seeding() {
+        let server_addr = "0.0.0.0:5551";
+        let socket = UdpSocket::bind(server_addr).await.unwrap();
+
+        let server = ScuttleServer::spawn("0.0.0.0:5552", vec![server_addr.into()]);
+
+        let mut buf = [0; BUF_SIZE];
+        let (len, _addr) = timeout(socket.recv_from(&mut buf)).await.unwrap();
+
+        match bincode::deserialize(&buf[..len]).unwrap() {
+            ScuttleButtMessage::Syn { .. } => (),
             message => panic!("unexpected message: {:?}", message),
         }
 


### PR DESCRIPTION
This patch adds a new `server` module, providing functionality for two
ScuttleButt instances on different machines to stay in sync.

The new `ScuttleServer` struct provides a UDP server which runs in the
background once spawned with `ScuttleServer::spawn`, automatically
replying to incoming gossip using the shared `ScuttleButt` mutex.

To propagate gossip to other servers, the `ScuttleServer::gossip` method
allows transmitting the current state to other instances. While it would
be possible to keep track of all incoming and outgoing conversations, to
allow for broadcasting updates to all known nodes, this is currently
still left to the consumer.

Fixes #2.